### PR TITLE
Add asynchronous FastAPI backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pika>=1.3.2",
     "msgpack_python>=0.5.6",
     "pydantic>=1.10.12",
-    "aiohttp>=3.8.0",
+    "httpx>=0.24.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pika>=1.3.2",
     "msgpack_python>=0.5.6",
     "pydantic>=1.10.12",
+    "aiohttp>=3.8.0",
 ]
 
 [project.urls]

--- a/src/keycloak_utils/authentication/fastapi.py
+++ b/src/keycloak_utils/authentication/fastapi.py
@@ -1,5 +1,6 @@
 import typing
 
+from asgiref.sync import sync_to_async
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -11,31 +12,15 @@ from ..backend.fastapi import (
 from ..errors import AuthInterruptedError, AuthSkipError
 
 
-class AsyncFastAPIKCAuthentication(BaseHTTPMiddleware):
-    """Async FastAPI Keycloak Authentication Middleware."""
+class _AbstractFastAPIKCAuthentication(BaseHTTPMiddleware):
+    """Common logic for FastAPI authentication middlewares."""
 
-    backends: typing.List[typing.Type[AsyncFastAPIKeycloakAuthBackend]]
-
-    def get_backend_context(
-        self,
-        request: Request,
-        **kwargs,
-    ) -> dict:
+    def get_backend_context(self, request: Request, **kwargs) -> dict:
         context = {"request": request, **kwargs}
         return context
 
     async def authenticate(self, request: Request) -> typing.Optional[dict]:
-        for backend in self.backends:
-            context = self.get_backend_context(request=request)
-            try:
-                backend_instance = backend(**context)
-                claims = await backend_instance.authenticate()
-            except AuthSkipError:
-                continue
-            except backend_instance.AuthError as e:
-                raise AuthInterruptedError(msg=str(e.msg))
-            if claims:
-                return claims
+        raise NotImplementedError
 
     async def post_process_claims(
         self, claims: typing.Optional[dict], request: Request
@@ -62,47 +47,39 @@ class AsyncFastAPIKCAuthentication(BaseHTTPMiddleware):
         return response
 
 
-class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
-    """Synchronous middleware retained for backwards compatibility."""
+class BaseFastAPIKCAuthentication(_AbstractFastAPIKCAuthentication):
+    """Synchronous backend middleware retained for backwards compatibility."""
 
     backends: typing.List[typing.Type[FastAPIKeycloakAuthBackend]]
 
-    def get_backend_context(self, request: Request, **kwargs) -> dict:
-        context = {"request": request, **kwargs}
-        return context
-
-    def authenticate(self, request: Request) -> typing.Optional[dict]:
+    async def authenticate(self, request: Request) -> typing.Optional[dict]:
         for backend in self.backends:
             context = self.get_backend_context(request=request)
             try:
-                claims = backend(**context).authenticate()
+                backend_instance = backend(**context)
+                claims = await sync_to_async(backend_instance.authenticate)()
             except AuthSkipError:
                 continue
-            except backend.AuthError as e:
+            except backend_instance.AuthError as e:
                 raise AuthInterruptedError(msg=str(e.msg))
             if claims:
                 return claims
 
-    def post_process_claims(
-        self, claims: typing.Optional[dict], request: Request
-    ) -> Request:
-        return request
 
-    def is_already_authenticated(self, request: Request) -> bool:
-        try:
-            return request.state.user.is_authenticated
-        except AttributeError:
-            return False
+class AsyncFastAPIKCAuthentication(_AbstractFastAPIKCAuthentication):
+    """Async FastAPI Keycloak Authentication Middleware."""
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
-        already_authenticated = self.is_already_authenticated(request=request)
-        if not already_authenticated:
+    backends: typing.List[typing.Type[AsyncFastAPIKeycloakAuthBackend]]
+
+    async def authenticate(self, request: Request) -> typing.Optional[dict]:
+        for backend in self.backends:
+            context = self.get_backend_context(request=request)
             try:
-                claims = self.authenticate(request=request)
-            except AuthInterruptedError as e:
-                return JSONResponse(status_code=401, content={"detail": str(e)})
-            request = self.post_process_claims(claims=claims, request=request)
-        response = await call_next(request)
-        return response
+                backend_instance = backend(**context)
+                claims = await backend_instance.authenticate()
+            except AuthSkipError:
+                continue
+            except backend_instance.AuthError as e:
+                raise AuthInterruptedError(msg=str(e.msg))
+            if claims:
+                return claims

--- a/src/keycloak_utils/authentication/fastapi.py
+++ b/src/keycloak_utils/authentication/fastapi.py
@@ -4,12 +4,17 @@ from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
-from ..backend.fastapi import FastAPIKeycloakAuthBackend
+from ..backend.fastapi import (
+    AsyncFastAPIKeycloakAuthBackend,
+    FastAPIKeycloakAuthBackend,
+)
 from ..errors import AuthInterruptedError, AuthSkipError
 
 
-class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
-    backends: typing.List[typing.Type[FastAPIKeycloakAuthBackend]]
+class AsyncFastAPIKCAuthentication(BaseHTTPMiddleware):
+    """Async FastAPI Keycloak Authentication Middleware."""
+
+    backends: typing.List[typing.Type[AsyncFastAPIKeycloakAuthBackend]]
 
     def get_backend_context(
         self,
@@ -19,23 +24,21 @@ class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
         context = {"request": request, **kwargs}
         return context
 
-    def authenticate(self, request: Request) -> typing.Optional[dict]:
+    async def authenticate(self, request: Request) -> typing.Optional[dict]:
         for backend in self.backends:
             context = self.get_backend_context(request=request)
             try:
-                claims = backend(**context).authenticate()
+                backend_instance = backend(**context)
+                claims = await backend_instance.authenticate()
             except AuthSkipError:
-                # Skip authentication for this backend
                 continue
-            except backend.AuthError as e:
+            except backend_instance.AuthError as e:
                 raise AuthInterruptedError(msg=str(e.msg))
             if claims:
                 return claims
 
-    def post_process_claims(
-        self,
-        claims: typing.Optional[dict],
-        request: Request,
+    async def post_process_claims(
+        self, claims: typing.Optional[dict], request: Request
     ) -> Request:
         return request
 
@@ -46,9 +49,53 @@ class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
             return False
 
     async def dispatch(
-        self,
-        request: Request,
-        call_next: RequestResponseEndpoint,
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        already_authenticated = self.is_already_authenticated(request=request)
+        if not already_authenticated:
+            try:
+                claims = await self.authenticate(request=request)
+            except AuthInterruptedError as e:
+                return JSONResponse(status_code=401, content={"detail": str(e)})
+            request = await self.post_process_claims(claims=claims, request=request)
+        response = await call_next(request)
+        return response
+
+
+class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
+    """Synchronous middleware retained for backwards compatibility."""
+
+    backends: typing.List[typing.Type[FastAPIKeycloakAuthBackend]]
+
+    def get_backend_context(self, request: Request, **kwargs) -> dict:
+        context = {"request": request, **kwargs}
+        return context
+
+    def authenticate(self, request: Request) -> typing.Optional[dict]:
+        for backend in self.backends:
+            context = self.get_backend_context(request=request)
+            try:
+                claims = backend(**context).authenticate()
+            except AuthSkipError:
+                continue
+            except backend.AuthError as e:
+                raise AuthInterruptedError(msg=str(e.msg))
+            if claims:
+                return claims
+
+    def post_process_claims(
+        self, claims: typing.Optional[dict], request: Request
+    ) -> Request:
+        return request
+
+    def is_already_authenticated(self, request: Request) -> bool:
+        try:
+            return request.state.user.is_authenticated
+        except AttributeError:
+            return False
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         already_authenticated = self.is_already_authenticated(request=request)
         if not already_authenticated:

--- a/src/keycloak_utils/authentication/fastapi.py
+++ b/src/keycloak_utils/authentication/fastapi.py
@@ -1,4 +1,5 @@
 import typing
+import inspect
 
 from asgiref.sync import sync_to_async
 from fastapi import Request, Response
@@ -42,7 +43,11 @@ class _AbstractFastAPIKCAuthentication(BaseHTTPMiddleware):
                 claims = await self.authenticate(request=request)
             except AuthInterruptedError as e:
                 return JSONResponse(status_code=401, content={"detail": str(e)})
-            request = await self.post_process_claims(claims=claims, request=request)
+            result = self.post_process_claims(claims=claims, request=request)
+            if inspect.isawaitable(result):
+                request = await result
+            else:
+                request = result
         response = await call_next(request)
         return response
 

--- a/src/keycloak_utils/backend/fastapi.py
+++ b/src/keycloak_utils/backend/fastapi.py
@@ -1,5 +1,123 @@
-from ..verifier.fastapi import FastAPITokenVerifier
+import typing
+
+from ..verifier.fastapi import AsyncFastAPITokenVerifier, FastAPITokenVerifier
+from ..errors import JWTDecodeError
 from .base import APIAuthMixin, BaseKCAuthBackend
+
+
+class AsyncFastAPIKeycloakAuthBackend:
+    """Async Keycloak authentication backend for FastAPI."""
+
+    def __init__(
+        self,
+        request,
+        host: typing.Optional[str] = None,
+        realm: typing.Optional[str] = None,
+        algorithms: typing.Optional[list[str]] = None,
+        audience: typing.Optional[str] = None,
+        auth_scheme: typing.Optional[str] = None,
+        *args,
+        **kwargs,
+    ):
+        self.request = request
+        self.kc_host = host or self.get_kc_host()
+        self.kc_realm = realm or self.get_kc_realm()
+        self.kc_algorithms = algorithms or self.get_kc_algorithms()
+        self.kc_audience = audience or self.get_kc_audience()
+        self.auth_scheme = auth_scheme or "Bearer"
+
+        from ..errors import AuthInterruptedError
+
+        self.AuthError = AuthInterruptedError
+
+    def get_kc_audience(self) -> str:
+        try:
+            return self.kc_audience
+        except AttributeError:
+            msg = (
+                f"'{self.__class__.__name__}' should either include a "
+                f"`kc_audience` attribute, or override the "
+                f"`get_kc_audience()` method."
+            )
+            raise NotImplementedError(msg)
+
+    def get_kc_algorithms(self) -> list[str]:
+        try:
+            return self.kc_algorithms
+        except AttributeError:
+            msg = (
+                f"'{self.__class__.__name__}' should either include a "
+                f"`kc_algorithms` attribute, or override the "
+                f"`get_kc_algorithms()` method."
+            )
+            raise NotImplementedError(msg)
+
+    def get_kc_host(self) -> str:
+        try:
+            return self.kc_host
+        except AttributeError:
+            msg = (
+                f"'{self.__class__.__name__}' should either include a "
+                f"`kc_host` attribute, or override the "
+                f"`get_kc_host()` method."
+            )
+            raise NotImplementedError(msg)
+
+    def get_kc_realm(self) -> str:
+        try:
+            return self.kc_realm
+        except AttributeError:
+            msg = (
+                f"'{self.__class__.__name__}' should either include a "
+                f"`kc_realm` attribute, or override the "
+                f"`get_kc_realm()` method."
+            )
+            raise NotImplementedError(msg)
+
+    def get_auth_header(self) -> str:
+        return self.request.headers.get("Authorization", "")
+
+    def validate_auth_headers(self) -> typing.Optional[str]:
+        headers = self.get_auth_header().split()
+        if len(headers) == 0:
+            return None
+        elif len(headers) == 1:
+            msg = "Invalid token header. No credentials provided."
+            raise self.AuthError(msg)
+        elif len(headers) > 2:
+            msg = "Invalid token header. Token string should not contain spaces."
+            raise self.AuthError(msg)
+
+        token_type, token = headers
+        if token_type.lower() != self.auth_scheme.lower():
+            return None
+        return token
+
+    def get_access_token(self) -> str:
+        return self.validate_auth_headers()
+
+    async def verify_access_token(self, token: str) -> dict:
+        try:
+            verifier = AsyncFastAPITokenVerifier(
+                access_token=token,
+                host=self.kc_host,
+                realm=self.kc_realm,
+                algorithms=self.kc_algorithms,
+                audience=self.kc_audience,
+            )
+            claims = await verifier.get_claims()
+            return await self.post_authenticate_hooks(claims)
+        except JWTDecodeError as e:
+            raise self.AuthError(e)
+
+    async def post_authenticate_hooks(self, claims: dict) -> dict:
+        return claims
+
+    async def authenticate(self) -> typing.Optional[dict]:
+        token = self.get_access_token()
+        if not token:
+            return None
+        return await self.verify_access_token(token=token)
 
 
 class FastAPIKeycloakAuthBackend(APIAuthMixin, BaseKCAuthBackend):

--- a/src/keycloak_utils/backend/fastapi.py
+++ b/src/keycloak_utils/backend/fastapi.py
@@ -1,104 +1,22 @@
 import typing
 
+from asgiref.sync import sync_to_async
+
 from ..verifier.fastapi import AsyncFastAPITokenVerifier, FastAPITokenVerifier
 from ..errors import JWTDecodeError
 from .base import APIAuthMixin, BaseKCAuthBackend
 
 
-class AsyncFastAPIKeycloakAuthBackend:
+class AsyncFastAPIKeycloakAuthBackend(APIAuthMixin, BaseKCAuthBackend):
     """Async Keycloak authentication backend for FastAPI."""
 
-    def __init__(
-        self,
-        request,
-        host: typing.Optional[str] = None,
-        realm: typing.Optional[str] = None,
-        algorithms: typing.Optional[list[str]] = None,
-        audience: typing.Optional[str] = None,
-        auth_scheme: typing.Optional[str] = None,
-        *args,
-        **kwargs,
-    ):
-        self.request = request
-        self.kc_host = host or self.get_kc_host()
-        self.kc_realm = realm or self.get_kc_realm()
-        self.kc_algorithms = algorithms or self.get_kc_algorithms()
-        self.kc_audience = audience or self.get_kc_audience()
-        self.auth_scheme = auth_scheme or "Bearer"
-
-        from ..errors import AuthInterruptedError
-
-        self.AuthError = AuthInterruptedError
-
-    def get_kc_audience(self) -> str:
-        try:
-            return self.kc_audience
-        except AttributeError:
-            msg = (
-                f"'{self.__class__.__name__}' should either include a "
-                f"`kc_audience` attribute, or override the "
-                f"`get_kc_audience()` method."
-            )
-            raise NotImplementedError(msg)
-
-    def get_kc_algorithms(self) -> list[str]:
-        try:
-            return self.kc_algorithms
-        except AttributeError:
-            msg = (
-                f"'{self.__class__.__name__}' should either include a "
-                f"`kc_algorithms` attribute, or override the "
-                f"`get_kc_algorithms()` method."
-            )
-            raise NotImplementedError(msg)
-
-    def get_kc_host(self) -> str:
-        try:
-            return self.kc_host
-        except AttributeError:
-            msg = (
-                f"'{self.__class__.__name__}' should either include a "
-                f"`kc_host` attribute, or override the "
-                f"`get_kc_host()` method."
-            )
-            raise NotImplementedError(msg)
-
-    def get_kc_realm(self) -> str:
-        try:
-            return self.kc_realm
-        except AttributeError:
-            msg = (
-                f"'{self.__class__.__name__}' should either include a "
-                f"`kc_realm` attribute, or override the "
-                f"`get_kc_realm()` method."
-            )
-            raise NotImplementedError(msg)
-
-    def get_auth_header(self) -> str:
-        return self.request.headers.get("Authorization", "")
-
-    def validate_auth_headers(self) -> typing.Optional[str]:
-        headers = self.get_auth_header().split()
-        if len(headers) == 0:
-            return None
-        elif len(headers) == 1:
-            msg = "Invalid token header. No credentials provided."
-            raise self.AuthError(msg)
-        elif len(headers) > 2:
-            msg = "Invalid token header. Token string should not contain spaces."
-            raise self.AuthError(msg)
-
-        token_type, token = headers
-        if token_type.lower() != self.auth_scheme.lower():
-            return None
-        return token
-
-    def get_access_token(self) -> str:
-        return self.validate_auth_headers()
+    verifier = AsyncFastAPITokenVerifier
 
     async def verify_access_token(self, token: str) -> dict:
+        """Verify the access token asynchronously."""
+
         try:
-            verifier = AsyncFastAPITokenVerifier(
+            verifier = self.verifier(
                 access_token=token,
                 host=self.kc_host,
                 realm=self.kc_realm,
@@ -106,12 +24,9 @@ class AsyncFastAPIKeycloakAuthBackend:
                 audience=self.kc_audience,
             )
             claims = await verifier.get_claims()
-            return await self.post_authenticate_hooks(claims)
+            return await sync_to_async(self.post_authenticate_hooks)(claims)
         except JWTDecodeError as e:
             raise self.AuthError(e)
-
-    async def post_authenticate_hooks(self, claims: dict) -> dict:
-        return claims
 
     async def authenticate(self) -> typing.Optional[dict]:
         token = self.get_access_token()

--- a/src/keycloak_utils/manager/fastapi.py
+++ b/src/keycloak_utils/manager/fastapi.py
@@ -13,8 +13,12 @@ class AsyncFastAPIKeyManager:
     ttl: int = 60 * 60 * 24  # 1 day
     host: str
     realm: str
-    _cache: dict = {}
-    _cache_lock = asyncio.Lock()
+    def __init__(self, host: typing.Optional[str] = None, realm: typing.Optional[str] = None):
+        self.host = host or ""
+        self.realm = realm or ""
+        self._cache_key = f"keycloak_public_key_{self.realm}"
+        self._cache: dict = {}
+        self._cache_lock = asyncio.Lock()
 
     def __init__(self, host: typing.Optional[str] = None, realm: typing.Optional[str] = None):
         self.host = host or ""

--- a/src/keycloak_utils/manager/fastapi.py
+++ b/src/keycloak_utils/manager/fastapi.py
@@ -1,5 +1,83 @@
+import asyncio
+import typing
+
+import aiohttp
+
+from ..errors import PublicKeyNotFound
 from .base import BasePublicKeyManager
 
 
+class AsyncFastAPIKeyManager:
+    """Asynchronous public key manager for FastAPI."""
+
+    ttl: int = 60 * 60 * 24  # 1 day
+    host: str
+    realm: str
+    _cache: dict = {}
+    _cache_lock = asyncio.Lock()
+
+    def __init__(self, host: typing.Optional[str] = None, realm: typing.Optional[str] = None):
+        self.host = host or ""
+        self.realm = realm or ""
+        self._cache_key = f"keycloak_public_key_{self.realm}"
+
+    @property
+    def url_realm(self) -> str:
+        return f"https://{self.host}/auth/realms/{self.realm}"
+
+    async def get_fresh_key_from_upstream(self) -> str:
+        """Fetch the public key from Keycloak using ``aiohttp``."""
+
+        timeout = aiohttp.ClientTimeout(total=10)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(self.url_realm) as response:
+                    if response.status != 200:
+                        msg = (
+                            f"Public key for Keycloak realm `{self.realm}` not found. "
+                            f"Status: {response.status}"
+                        )
+                        raise PublicKeyNotFound(msg)
+
+                    data = await response.json()
+                    return data.get("public_key")
+        except aiohttp.ClientError as e:
+            raise PublicKeyNotFound(f"Failed to fetch public key: {str(e)}") from e
+        except asyncio.TimeoutError:
+            raise PublicKeyNotFound(f"Timeout fetching public key from {self.url_realm}")
+
+    async def get_fresh_pem_key(self) -> str:
+        key = await self.get_fresh_key_from_upstream()
+        return f"-----BEGIN PUBLIC KEY-----\n{key}\n-----END PUBLIC KEY-----"
+
+    async def clear_cache(self) -> None:
+        async with self._cache_lock:
+            self._cache.clear()
+
+    async def get_key_from_cache(self) -> typing.Optional[str]:
+        async with self._cache_lock:
+            return self._cache.get(self._cache_key)
+
+    async def set_key(self, key: str) -> str:
+        async with self._cache_lock:
+            self._cache[self._cache_key] = key
+        return key
+
+    async def get_or_set_key(self) -> str:
+        key = await self.get_key_from_cache()
+        if key:
+            return key
+        key = await self.get_fresh_pem_key()
+        await self.set_key(key)
+        return key
+
+    async def get_key(self, force: bool = False) -> str:
+        if force:
+            await self.clear_cache()
+        return await self.get_or_set_key()
+
+
 class FastAPIKeyManager(BasePublicKeyManager):
-    ...
+    """Synchronous version retained for backwards compatibility."""
+    pass
+

--- a/src/keycloak_utils/verifier/fastapi.py
+++ b/src/keycloak_utils/verifier/fastapi.py
@@ -1,6 +1,41 @@
-from ..manager.fastapi import FastAPIKeyManager
+import typing
+
+from ..manager.fastapi import AsyncFastAPIKeyManager, FastAPIKeyManager
+from ..utils import verify_token
 from .base import BaseTokenVerifier
 
 
+class AsyncFastAPITokenVerifier:
+    """Async token verifier for FastAPI."""
+
+    def __init__(
+        self,
+        access_token: str,
+        host: str,
+        realm: str,
+        algorithms: list[str],
+        audience: str,
+    ):
+        self.access_token = access_token
+        self.host = host
+        self.realm = realm
+        self.algorithms = algorithms
+        self.audience = audience
+        self.manager = AsyncFastAPIKeyManager(host=host, realm=realm)
+
+    async def get_claims(self, force: bool = False) -> dict:
+        """Verify the token asynchronously using the public key."""
+
+        public_key = await self.manager.get_key(force=force)
+        return verify_token(
+            access_token=self.access_token,
+            public_key=public_key,
+            algorithms=self.algorithms,
+            audience=self.audience,
+        )
+
+
 class FastAPITokenVerifier(BaseTokenVerifier):
+    """Synchronous verifier retained for backwards compatibility."""
+
     manager = FastAPIKeyManager

--- a/src/keycloak_utils/verifier/fastapi.py
+++ b/src/keycloak_utils/verifier/fastapi.py
@@ -1,5 +1,7 @@
 import typing
 
+from asgiref.sync import sync_to_async
+
 from ..manager.fastapi import AsyncFastAPIKeyManager, FastAPIKeyManager
 from ..utils import verify_token
 from .base import BaseTokenVerifier
@@ -27,7 +29,7 @@ class AsyncFastAPITokenVerifier:
         """Verify the token asynchronously using the public key."""
 
         public_key = await self.manager.get_key(force=force)
-        return verify_token(
+        return await sync_to_async(verify_token)(
             access_token=self.access_token,
             public_key=public_key,
             algorithms=self.algorithms,


### PR DESCRIPTION
## Summary
- implement asynchronous manager using aiohttp
- implement async token verifier and auth backend
- provide async FastAPI middleware
- add aiohttp dependency

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_683ae3174848832682c84f10511b8197