### PR TITLE
Add asynchronous FastAPI backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Tests with tox
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
 
 jobs:
@@ -26,5 +24,4 @@ jobs:
         pip install tox -U
     - name: Run Tests
       run: |
-        export PYTHONPATH="${{ github.workspace }}"
         tox -r -vvv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Tests with tox
 
 on:
+  push:
+    branches: ["**"]
   pull_request:
 
 jobs:
@@ -24,4 +26,5 @@ jobs:
         pip install tox -U
     - name: Run Tests
       run: |
+        export PYTHONPATH="${{ github.workspace }}"
         tox -r -vvv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pika>=1.3.2",
     "msgpack_python>=0.5.6",
     "pydantic>=1.10.12",
+    "httpx>=0.24.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "msgpack_python>=0.5.6",
     "pydantic>=1.10.12",
     "httpx>=0.24.0",
+    "asgiref>=3.6.0"
 ]
 
 [project.urls]

--- a/src/keycloak_utils/authentication/fastapi.py
+++ b/src/keycloak_utils/authentication/fastapi.py
@@ -1,41 +1,30 @@
 import typing
+import inspect
 
+from asgiref.sync import sync_to_async
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
-from ..backend.fastapi import FastAPIKeycloakAuthBackend
+from ..backend.fastapi import (
+    AsyncFastAPIKeycloakAuthBackend,
+    FastAPIKeycloakAuthBackend,
+)
 from ..errors import AuthInterruptedError, AuthSkipError
 
 
-class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
-    backends: typing.List[typing.Type[FastAPIKeycloakAuthBackend]]
+class _AbstractFastAPIKCAuthentication(BaseHTTPMiddleware):
+    """Common logic for FastAPI authentication middlewares."""
 
-    def get_backend_context(
-        self,
-        request: Request,
-        **kwargs,
-    ) -> dict:
+    def get_backend_context(self, request: Request, **kwargs) -> dict:
         context = {"request": request, **kwargs}
         return context
 
-    def authenticate(self, request: Request) -> typing.Optional[dict]:
-        for backend in self.backends:
-            context = self.get_backend_context(request=request)
-            try:
-                claims = backend(**context).authenticate()
-            except AuthSkipError:
-                # Skip authentication for this backend
-                continue
-            except backend.AuthError as e:
-                raise AuthInterruptedError(msg=str(e.msg))
-            if claims:
-                return claims
+    async def authenticate(self, request: Request) -> typing.Optional[dict]:
+        raise NotImplementedError
 
-    def post_process_claims(
-        self,
-        claims: typing.Optional[dict],
-        request: Request,
+    async def post_process_claims(
+        self, claims: typing.Optional[dict], request: Request
     ) -> Request:
         return request
 
@@ -46,16 +35,56 @@ class BaseFastAPIKCAuthentication(BaseHTTPMiddleware):
             return False
 
     async def dispatch(
-        self,
-        request: Request,
-        call_next: RequestResponseEndpoint,
+        self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         already_authenticated = self.is_already_authenticated(request=request)
         if not already_authenticated:
             try:
-                claims = self.authenticate(request=request)
+                claims = await self.authenticate(request=request)
             except AuthInterruptedError as e:
                 return JSONResponse(status_code=401, content={"detail": str(e)})
-            request = self.post_process_claims(claims=claims, request=request)
+            result = self.post_process_claims(claims=claims, request=request)
+            if inspect.isawaitable(result):
+                request = await result
+            else:
+                request = result
         response = await call_next(request)
         return response
+
+
+class BaseFastAPIKCAuthentication(_AbstractFastAPIKCAuthentication):
+    """Synchronous backend middleware retained for backwards compatibility."""
+
+    backends: typing.List[typing.Type[FastAPIKeycloakAuthBackend]]
+
+    async def authenticate(self, request: Request) -> typing.Optional[dict]:
+        for backend in self.backends:
+            context = self.get_backend_context(request=request)
+            try:
+                backend_instance = backend(**context)
+                claims = await sync_to_async(backend_instance.authenticate)()
+            except AuthSkipError:
+                continue
+            except backend_instance.AuthError as e:
+                raise AuthInterruptedError(msg=str(e.msg))
+            if claims:
+                return claims
+
+
+class AsyncFastAPIKCAuthentication(_AbstractFastAPIKCAuthentication):
+    """Async FastAPI Keycloak Authentication Middleware."""
+
+    backends: typing.List[typing.Type[AsyncFastAPIKeycloakAuthBackend]]
+
+    async def authenticate(self, request: Request) -> typing.Optional[dict]:
+        for backend in self.backends:
+            context = self.get_backend_context(request=request)
+            try:
+                backend_instance = backend(**context)
+                claims = await backend_instance.authenticate()
+            except AuthSkipError:
+                continue
+            except backend_instance.AuthError as e:
+                raise AuthInterruptedError(msg=str(e.msg))
+            if claims:
+                return claims

--- a/src/keycloak_utils/authentication/fastapi.py
+++ b/src/keycloak_utils/authentication/fastapi.py
@@ -1,5 +1,5 @@
-import typing
 import inspect
+import typing
 
 from asgiref.sync import sync_to_async
 from fastapi import Request, Response
@@ -24,7 +24,9 @@ class _AbstractFastAPIKCAuthentication(BaseHTTPMiddleware):
         raise NotImplementedError
 
     async def post_process_claims(
-        self, claims: typing.Optional[dict], request: Request
+        self,
+        claims: typing.Optional[dict],
+        request: Request,
     ) -> Request:
         return request
 
@@ -35,7 +37,9 @@ class _AbstractFastAPIKCAuthentication(BaseHTTPMiddleware):
             return False
 
     async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
     ) -> Response:
         already_authenticated = self.is_already_authenticated(request=request)
         if not already_authenticated:

--- a/src/keycloak_utils/backend/fastapi.py
+++ b/src/keycloak_utils/backend/fastapi.py
@@ -2,8 +2,8 @@ import typing
 
 from asgiref.sync import sync_to_async
 
-from ..verifier.fastapi import AsyncFastAPITokenVerifier, FastAPITokenVerifier
 from ..errors import JWTDecodeError
+from ..verifier.fastapi import AsyncFastAPITokenVerifier, FastAPITokenVerifier
 from .base import APIAuthMixin, BaseKCAuthBackend
 
 

--- a/src/keycloak_utils/backend/fastapi.py
+++ b/src/keycloak_utils/backend/fastapi.py
@@ -1,5 +1,38 @@
-from ..verifier.fastapi import FastAPITokenVerifier
+import typing
+
+from asgiref.sync import sync_to_async
+
+from ..verifier.fastapi import AsyncFastAPITokenVerifier, FastAPITokenVerifier
+from ..errors import JWTDecodeError
 from .base import APIAuthMixin, BaseKCAuthBackend
+
+
+class AsyncFastAPIKeycloakAuthBackend(APIAuthMixin, BaseKCAuthBackend):
+    """Async Keycloak authentication backend for FastAPI."""
+
+    verifier = AsyncFastAPITokenVerifier
+
+    async def verify_access_token(self, token: str) -> dict:
+        """Verify the access token asynchronously."""
+
+        try:
+            verifier = self.verifier(
+                access_token=token,
+                host=self.kc_host,
+                realm=self.kc_realm,
+                algorithms=self.kc_algorithms,
+                audience=self.kc_audience,
+            )
+            claims = await verifier.get_claims()
+            return await sync_to_async(self.post_authenticate_hooks)(claims)
+        except JWTDecodeError as e:
+            raise self.AuthError(e)
+
+    async def authenticate(self) -> typing.Optional[dict]:
+        token = self.get_access_token()
+        if not token:
+            return None
+        return await self.verify_access_token(token=token)
 
 
 class FastAPIKeycloakAuthBackend(APIAuthMixin, BaseKCAuthBackend):

--- a/src/keycloak_utils/manager/fastapi.py
+++ b/src/keycloak_utils/manager/fastapi.py
@@ -1,5 +1,82 @@
+import asyncio
+import typing
+
+import httpx
+
+from ..errors import PublicKeyNotFound
 from .base import BasePublicKeyManager
 
 
+class AsyncFastAPIKeyManager:
+    """Asynchronous public key manager for FastAPI."""
+
+    ttl: int = 60 * 60 * 24  # 1 day
+    host: str
+    realm: str
+    _cache: dict = {}
+    _cache_lock = asyncio.Lock()
+
+    def __init__(self, host: typing.Optional[str] = None, realm: typing.Optional[str] = None):
+        self.host = host or ""
+        self.realm = realm or ""
+        self._cache_key = f"keycloak_public_key_{self.realm}"
+
+    @property
+    def url_realm(self) -> str:
+        return f"https://{self.host}/auth/realms/{self.realm}"
+
+    async def get_fresh_key_from_upstream(self) -> str:
+        """Fetch the public key from Keycloak using ``httpx``."""
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.get(self.url_realm)
+                if response.status_code != 200:
+                    msg = (
+                        f"Public key for Keycloak realm `{self.realm}` not found. "
+                        f"Status: {response.status_code}"
+                    )
+                    raise PublicKeyNotFound(msg)
+
+                data = response.json()
+                return data.get("public_key")
+        except httpx.RequestError as e:
+            raise PublicKeyNotFound(f"Failed to fetch public key: {str(e)}") from e
+        except asyncio.TimeoutError:
+            raise PublicKeyNotFound(f"Timeout fetching public key from {self.url_realm}")
+
+    async def get_fresh_pem_key(self) -> str:
+        key = await self.get_fresh_key_from_upstream()
+        return f"-----BEGIN PUBLIC KEY-----\n{key}\n-----END PUBLIC KEY-----"
+
+    async def clear_cache(self) -> None:
+        async with self._cache_lock:
+            self._cache.clear()
+
+    async def get_key_from_cache(self) -> typing.Optional[str]:
+        async with self._cache_lock:
+            return self._cache.get(self._cache_key)
+
+    async def set_key(self, key: str) -> str:
+        async with self._cache_lock:
+            self._cache[self._cache_key] = key
+        return key
+
+    async def get_or_set_key(self) -> str:
+        key = await self.get_key_from_cache()
+        if key:
+            return key
+        key = await self.get_fresh_pem_key()
+        await self.set_key(key)
+        return key
+
+    async def get_key(self, force: bool = False) -> str:
+        if force:
+            await self.clear_cache()
+        return await self.get_or_set_key()
+
+
 class FastAPIKeyManager(BasePublicKeyManager):
-    ...
+    """Synchronous version retained for backwards compatibility."""
+    pass
+

--- a/src/keycloak_utils/manager/fastapi.py
+++ b/src/keycloak_utils/manager/fastapi.py
@@ -16,10 +16,17 @@ class AsyncFastAPIKeyManager:
     _cache: dict = {}
     _cache_lock = asyncio.Lock()
 
-    def __init__(self, host: typing.Optional[str] = None, realm: typing.Optional[str] = None):
+    def __init__(
+        self,
+        host: typing.Optional[str] = None,
+        realm: typing.Optional[str] = None,
+        ttl: typing.Optional[int] = None,
+    ) -> None:
         self.host = host or ""
         self.realm = realm or ""
         self._cache_key = f"keycloak_public_key_{self.realm}"
+        if ttl is not None:
+            self.ttl = ttl
 
     @property
     def url_realm(self) -> str:
@@ -39,11 +46,18 @@ class AsyncFastAPIKeyManager:
                     raise PublicKeyNotFound(msg)
 
                 data = response.json()
-                return data.get("public_key")
+                key = data.get("public_key")
+                if not key:
+                    raise PublicKeyNotFound(
+                        f"Public key for Keycloak realm `{self.realm}` not found",
+                    )
+                return key
         except httpx.RequestError as e:
             raise PublicKeyNotFound(f"Failed to fetch public key: {str(e)}") from e
         except asyncio.TimeoutError:
-            raise PublicKeyNotFound(f"Timeout fetching public key from {self.url_realm}")
+            raise PublicKeyNotFound(
+                f"Timeout fetching public key from {self.url_realm}",
+            )
 
     async def get_fresh_pem_key(self) -> str:
         key = await self.get_fresh_key_from_upstream()
@@ -55,11 +69,18 @@ class AsyncFastAPIKeyManager:
 
     async def get_key_from_cache(self) -> typing.Optional[str]:
         async with self._cache_lock:
-            return self._cache.get(self._cache_key)
+            cached = self._cache.get(self._cache_key)
+        if not cached:
+            return None
+        key, ts = cached
+        if ts + self.ttl < asyncio.get_running_loop().time():
+            # expired
+            return None
+        return key
 
     async def set_key(self, key: str) -> str:
         async with self._cache_lock:
-            self._cache[self._cache_key] = key
+            self._cache[self._cache_key] = (key, asyncio.get_running_loop().time())
         return key
 
     async def get_or_set_key(self) -> str:
@@ -78,5 +99,5 @@ class AsyncFastAPIKeyManager:
 
 class FastAPIKeyManager(BasePublicKeyManager):
     """Synchronous version retained for backwards compatibility."""
-    pass
 
+    pass

--- a/src/keycloak_utils/verifier/fastapi.py
+++ b/src/keycloak_utils/verifier/fastapi.py
@@ -1,5 +1,3 @@
-import typing
-
 from asgiref.sync import sync_to_async
 
 from ..manager.fastapi import AsyncFastAPIKeyManager, FastAPIKeyManager

--- a/src/keycloak_utils/verifier/fastapi.py
+++ b/src/keycloak_utils/verifier/fastapi.py
@@ -1,6 +1,43 @@
-from ..manager.fastapi import FastAPIKeyManager
+import typing
+
+from asgiref.sync import sync_to_async
+
+from ..manager.fastapi import AsyncFastAPIKeyManager, FastAPIKeyManager
+from ..utils import verify_token
 from .base import BaseTokenVerifier
 
 
+class AsyncFastAPITokenVerifier:
+    """Async token verifier for FastAPI."""
+
+    def __init__(
+        self,
+        access_token: str,
+        host: str,
+        realm: str,
+        algorithms: list[str],
+        audience: str,
+    ):
+        self.access_token = access_token
+        self.host = host
+        self.realm = realm
+        self.algorithms = algorithms
+        self.audience = audience
+        self.manager = AsyncFastAPIKeyManager(host=host, realm=realm)
+
+    async def get_claims(self, force: bool = False) -> dict:
+        """Verify the token asynchronously using the public key."""
+
+        public_key = await self.manager.get_key(force=force)
+        return await sync_to_async(verify_token)(
+            access_token=self.access_token,
+            public_key=public_key,
+            algorithms=self.algorithms,
+            audience=self.audience,
+        )
+
+
 class FastAPITokenVerifier(BaseTokenVerifier):
+    """Synchronous verifier retained for backwards compatibility."""
+
     manager = FastAPIKeyManager


### PR DESCRIPTION
## Summary
- implement async public key manager using httpx
- refactor AsyncFastAPIKeycloakAuthBackend to extend BaseKCAuthBackend
- create shared abstract FastAPI middleware
- add httpx dependency
- run token verification in executor when async
- support sync `post_process_claims` implementations in middleware
- run GitHub CI on push and set PYTHONPATH so tox tests run
- include fastapi in testing extras

## Testing
- `pre-commit` *(fails: style violations)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ae3174848832682c84f10511b8197