### PR TITLE
Fix tox env list for fastapi tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     {py39, py310}-drf-{314}
-    {py39, py310}-fastapi-{0100}
+    {py39, py310}-fastapi-{0111}
 minversion = 4.11.1
 
 [testenv]


### PR DESCRIPTION
## Summary
- ensure tox runs FastAPI integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6848402bfc5083269242d0d24188a749